### PR TITLE
follow up fix for backport: system-packages from the JVM for export

### DIFF
--- a/org.eclipse.pde.build/META-INF/MANIFEST.MF
+++ b/org.eclipse.pde.build/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.pde.build;singleton:=true
-Bundle-Version: 3.11.100.qualifier
+Bundle-Version: 3.11.200.qualifier
 Bundle-ClassPath: pdebuild.jar
 Bundle-Activator: org.eclipse.pde.internal.build.BuildActivator
 Bundle-Vendor: %providerName
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.equinox.p2.publisher;bundle-version="1.1.0",
  org.eclipse.equinox.p2.repository.tools;bundle-version="[2.0.0,3.0.0)";resolution:=optional,
  org.eclipse.equinox.p2.director.app;bundle-version="1.0.200",
- org.eclipse.equinox.p2.publisher.eclipse;bundle-version="1.0.0"
+ org.eclipse.equinox.p2.publisher.eclipse;bundle-version="1.0.0",
  org.eclipse.jdt.core;bundle-version="[3.28.0,4.0.0)",
  org.eclipse.jdt.launching;bundle-version="[3.2.0,4.0.0)"
 Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",


### PR DESCRIPTION
 - add a missing comma in the manifest

this is a suprise to me, as both the local builds did not catch this. Or is it that the comma was removed inadvertently, later on? :( 

 - bump the bundle version due to the change (we missed it last time)

Refs: https://github.com/eclipse-pde/eclipse.pde.build/pull/16